### PR TITLE
Patch petsc-3.5.4 config checkMPICHorOpenMPI()

### DIFF
--- a/petsc/3.5.4/config/BuildSystem/config/packages/MPI.py
+++ b/petsc/3.5.4/config/BuildSystem/config/packages/MPI.py
@@ -728,20 +728,36 @@ class Configure(config.package.Package):
     '''Determine if MPICH_NUMVERSION or OMPI_MAJOR_VERSION exist in mpi.h
        Used for consistency checking of MPI installation at compile time'''
     import re
-    mpich_test = '#include <mpi.h>\nint mpich_ver = MPICH_NUMVERSION;\n'
+    HASHLINESPACE = ' *(?:\n#.*\n *)*'
+    oldFlags = self.compilers.CPPFLAGS
+    self.compilers.CPPFLAGS += ' '+self.headers.toString(self.include)
+    for mpichpkg in ['i_mpi','mvapich2','mpich']:
+      MPICHPKG = mpichpkg.upper()
+      mpich_test = '#include <mpi.h>\nint mpich_ver = '+MPICHPKG+'_NUMVERSION;\n'
+      if self.checkCompile(mpich_test):
+        buf = self.outputPreprocess(mpich_test)
+        try:
+          mpich_numversion = re.compile('\nint mpich_ver ='+HASHLINESPACE+'([0-9]+)'+HASHLINESPACE+';').search(buf).group(1)
+          self.addDefine('HAVE_'+MPICHPKG+'_NUMVERSION',mpich_numversion)
+        except:
+          self.logPrint('Unable to parse '+MPICHPKG+' version from header. Probably a buggy preprocessor')
+        self.compilers.CPPFLAGS = oldFlags
+        return
     openmpi_test = '#include <mpi.h>\nint ompi_major = OMPI_MAJOR_VERSION;\nint ompi_minor = OMPI_MINOR_VERSION;\nint ompi_release = OMPI_RELEASE_VERSION;\n'
-    if self.checkCompile(mpich_test):
-      buf = self.outputPreprocess(mpich_test)
-      mpich_numversion = re.compile('\nint mpich_ver = *([0-9]*) *;').search(buf).group(1)
-      self.addDefine('HAVE_MPICH_NUMVERSION',mpich_numversion)
-    elif self.checkCompile(openmpi_test):
+    if self.checkCompile(openmpi_test):
       buf = self.outputPreprocess(openmpi_test)
-      ompi_major_version = re.compile('\nint ompi_major = *([0-9]*) *;').search(buf).group(1)
-      ompi_minor_version = re.compile('\nint ompi_minor = *([0-9]*) *;').search(buf).group(1)
-      ompi_release_version = re.compile('\nint ompi_release = *([0-9]*) *;').search(buf).group(1)
-      self.addDefine('HAVE_OMPI_MAJOR_VERSION',ompi_major_version)
-      self.addDefine('HAVE_OMPI_MINOR_VERSION',ompi_minor_version)
-      self.addDefine('HAVE_OMPI_RELEASE_VERSION',ompi_release_version)
+      ompi_major_version = ompi_minor_version = ompi_release_version = 'unknown'
+      try:
+        ompi_major_version = re.compile('\nint ompi_major ='+HASHLINESPACE+'([0-9]+)'+HASHLINESPACE+';').search(buf).group(1)
+        ompi_minor_version = re.compile('\nint ompi_minor ='+HASHLINESPACE+'([0-9]+)'+HASHLINESPACE+';').search(buf).group(1)
+        ompi_release_version = re.compile('\nint ompi_release ='+HASHLINESPACE+'([0-9]+)'+HASHLINESPACE+';').search(buf).group(1)
+        self.addDefine('HAVE_OMPI_MAJOR_VERSION',ompi_major_version)
+        self.addDefine('HAVE_OMPI_MINOR_VERSION',ompi_minor_version)
+        self.addDefine('HAVE_OMPI_RELEASE_VERSION',ompi_release_version)
+      except:
+        self.logPrint('Unable to parse OpenMPI version from header. Probably a buggy preprocessor')
+    self.compilers.CPPFLAGS = oldFlags
+    return
   def findMPIInc(self):
     '''Find MPI include paths from "mpicc -show"'''
     import re


### PR DESCRIPTION
Configure would crash with Open MPI 2.1.2
Updated checkMPICHorOpenMPI() python routine with its latest version (v3.8.3)
and configuration went through.